### PR TITLE
Specify max Node.js supported version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ You need:
 
 - Docker >= 19.03.8
 - Docker Compose >= 1.28.0
-- Node.js >= 12.16.1
+- Node.js >= 12.16.1 && < 16.0.0
 
 This is the new beabee frontend, it will slowly replace the old user interface
 and [beabee/beabee](https://github.com/beabee-communityrm/beabee) will become a pure API.


### PR DESCRIPTION
`fibers` dependency doesn't support Node.js v16.0.0 or later.

See https://github.com/laverdet/node-fibers/commit/8f2809869cc92c28c92880c4a38317ae3dbe654d for details.

Since it seems `fibers` is not being used it can be removed.